### PR TITLE
tile cutting: added lod/tile:range support

### DIFF
--- a/vef/CMakeLists.txt
+++ b/vef/CMakeLists.txt
@@ -1,5 +1,5 @@
 # bump version here
-set(vef_VERSION 1.10)
+set(vef_VERSION 1.11)
 
 set(vef_EXTRA_DEPENDS)
 set(vef_EXTRA_SOURCES)

--- a/vef/tilecutter.cpp
+++ b/vef/tilecutter.cpp
@@ -76,8 +76,6 @@ WindowRecord::list windowRecordList(const vef::Archive &archive
         std::size_t bLod(0);
         std::size_t eLod(lw.lods.size());
 
-        // TODO: apply tileExtents lod as well
-
         if (config.lodDepth > 0) {
             // >0 -> only first lodDepth lods
             eLod = std::min(std::size_t(config.lodDepth), eLod);
@@ -91,6 +89,7 @@ WindowRecord::list windowRecordList(const vef::Archive &archive
 
         std::size_t i(0);
         for (const auto &w : lw.lods) {
+            // TODO: apply tileExtents lod here as well
             if ((i >= bLod) && (i < eLod)) {
                 list.emplace_back(w, lod, trafo);
             }

--- a/vef/tilecutter.cpp
+++ b/vef/tilecutter.cpp
@@ -65,24 +65,25 @@ struct WindowRecord {
 };
 
 WindowRecord::list windowRecordList(const vef::Archive &archive
-                                    , vts::Lod maxLod
-                                    , int lodDepth)
+                                    , const TileCutterConfig &config)
 {
     WindowRecord::list list;
 
     for (const auto &lw : archive.manifest().windows) {
         const auto trafo(vef::windowMatrix(archive.manifest(), lw));
-        auto lod(maxLod);
+        auto lod(config.maxLod);
 
         std::size_t bLod(0);
         std::size_t eLod(lw.lods.size());
 
-        if (lodDepth > 0) {
+        // TODO: apply tileExtents lod as well
+
+        if (config.lodDepth > 0) {
             // >0 -> only first lodDepth lods
-            eLod = std::min(std::size_t(lodDepth), eLod);
-        } else if (lodDepth < 0) {
+            eLod = std::min(std::size_t(config.lodDepth), eLod);
+        } else if (config.lodDepth < 0) {
             // <0 -> only last lodDepth lods
-            const std::size_t ld(-lodDepth);
+            const std::size_t ld(-config.lodDepth);
             if (ld < eLod) {
                 bLod = eLod - ld;
             }
@@ -146,20 +147,35 @@ operator<<(std::basic_ostream<CharT, Traits> &os, const Done &d)
     return os << '#' << d.count;
 }
 
+math::Extents2 horizontalExtents(const TileCutterConfig &config)
+{
+    return std::visit([](const auto &e) { return math::extents2(e); }
+        , config.worldExtents);
+}
+
+math::Extent verticalExtent(const TileCutterConfig &config)
+{
+    return std::visit([](const auto &e) { return math::extent(e, 2); }
+        , config.worldExtents);
+}
+
+vts::Ranges computeClipRanges(const TileCutterConfig &config)
+{
+    if (config.tileExtents) {
+        return vts::Ranges(*config.tileExtents, config.maxLod);
+    }
+    return {};
+}
+
 class Cutter {
 public:
     Cutter(tools::TmpTileset &ts, const vef::Archive &archive
-           , const math::Extents2 &worldExtents
-           , const math::Extent &verticalExtent
-           , const boost::optional<geo::SrsDefinition> &dstSrs
-           , int maxLod, double clipMargin
-           , int lodDepth)
-        : ts_(ts), archive_(archive)
-        , worldExtents_(worldExtents)
-        , verticalExtent_(verticalExtent)
-        , dstSrs_(dstSrs)
-        , clipMargin_(clipMargin)
-        , windows_(windowRecordList(archive_, maxLod, lodDepth))
+           , const TileCutterConfig &config)
+        : ts_(ts), archive_(archive), config_(config)
+        , worldExtents_(horizontalExtents(config_))
+        , verticalExtent_(verticalExtent(config_))
+        , clipRanges_(computeClipRanges(config_))
+        , windows_(windowRecordList(archive_, config))
         , generated_(), total_(windows_.size())
     {
         LOG(info3) << "Cutting " << archive.path() << " into tiles.";
@@ -181,10 +197,10 @@ private:
 
     tools::TmpTileset &ts_;
     const vef::Archive &archive_;
-    const math::Extents2& worldExtents_;
-    const math::Extent& verticalExtent_;
-    const boost::optional<geo::SrsDefinition> &dstSrs_;
-    const double clipMargin_;
+    const TileCutterConfig config_;
+    const math::Extents2 worldExtents_;
+    const math::Extent verticalExtent_;
+    const vts::Ranges clipRanges_;
     WindowRecord::list windows_;
     std::atomic<std::size_t> generated_;
     std::size_t total_;
@@ -192,13 +208,13 @@ private:
 
 geo::CsConvertor Cutter::vef2world() const
 {
-    if (!dstSrs_) { return {}; }
-    return geo::CsConvertor(archive_.manifest().srs.value(), *dstSrs_);
+    if (!config_.dstSrs) { return {}; }
+    return geo::CsConvertor(archive_.manifest().srs.value()
+                            , *config_.dstSrs);
 }
 
 void Cutter::operator()(/**vt::ExternalProgress &progress*/)
 {
-    boost::optional<geo::CsConvertor> convertor;
     UTILITY_OMP(parallel)
     {
         const auto convertor(vef2world());
@@ -244,9 +260,20 @@ vts::TileSpan computeVerticalTileSpan(const math::Extent &rootExtent
     return s;
 }
 
-vts::TileRange computeTileRange(const math::Extents2 &worldExtents
-                                , vts::Lod lod
-                                , const math::Extents2 &meshExtents)
+std::optional<vts::TileRange>
+clipRange(const vts::Ranges &ranges, vts::Lod lod)
+{
+    if (const auto range = ranges.tileRange(lod, std::nothrow)) {
+        return *range;
+    }
+    return std::nullopt;
+}
+
+vts::TileRange
+computeTileRange(const math::Extents2 &worldExtents
+                 , vts::Lod lod
+                 , const math::Extents2 &meshExtents
+                 , const std::optional<vts::TileRange> &clipRange)
 {
     vts::TileRange r(math::InvalidExtents{});
     const auto ts(vts::tileSize(worldExtents, lod));
@@ -258,12 +285,27 @@ vts::TileRange computeTileRange(const math::Extents2 &worldExtents
                 , (origin(1) - p(1)) / ts.height));
     }
 
+    // apply tile extents at given LOD
+    if (clipRange) {
+        r = vts::tileRangesIntersect(r, *clipRange, std::nothrow);
+    }
+
     return r;
 }
 
 void Cutter::windowCut(const WindowRecord &wr, const geo::CsConvertor &conv)
 {
     const auto &window(*wr.window);
+
+    if (config_.tileExtents && (wr.lod < config_.tileExtents->lod)) {
+        // FIXME: this should be checked in generation of window records
+        Done done(++generated_, total_);
+        LOG(info3)
+            << "Skipped window outside of configured tile extents "
+            << done << ": " << window.path<< ".";
+        return;
+    }
+
     const auto &wm(window.mesh);
     LOG(info2) << "Cutting window mesh from " << wm.path << ".";
     auto mesh(vts::loadMeshFromObj(*archive_.meshIStream(wm), wm.path));
@@ -285,7 +327,17 @@ void Cutter::windowCut(const WindowRecord &wr, const geo::CsConvertor &conv)
 
     const auto atlas(loadAtlas(archive_, window));
 
-    auto tr(computeTileRange(worldExtents_, wr.lod, computeExtents(mesh)));
+    auto tr(computeTileRange
+            (worldExtents_, wr.lod, computeExtents(mesh)
+             , clipRange(clipRanges_, wr.lod)));
+    if (!math::valid(tr)) {
+        Done done(++generated_, total_);
+        LOG(info3)
+            << "Skipped window outside of configured tile extents "
+            << done << ": " << window.path<< ".";
+        return;
+    }
+
     LOG(info2) << "Splitting window " << window.path
                << " to tiles in " << wr.lod << "/" << tr << ".";
     splitToTiles(wr.lod, tr, mesh, atlas);
@@ -350,7 +402,7 @@ void Cutter::tileCut(const vts::TileId &tileId, const vts::Mesh &mesh
 {
     auto extents
         (vts::inflateTileExtents
-         (tileExtents(worldExtents_, tileId), clipMargin_));
+         (tileExtents(worldExtents_, tileId), config_.clipMargin));
 
     vts::Mesh clipped;
     vts::opencv::Atlas clippedAtlas(0); // PNG!
@@ -369,7 +421,7 @@ void Cutter::tileCut(const vts::TileId &tileId, const vts::Mesh &mesh
             for (auto i(ts.l); i <= ts.r; ++i) {
                 auto ve(inflateTileExtent
                         (tileVerticalExtent(verticalExtent_, tileId.lod, i)
-                         , clipMargin_));
+                         , config_.clipMargin));
 
                 auto vm(vts::clip(m, ve));
                 if (vm.empty()) { continue; }
@@ -398,24 +450,41 @@ void Cutter::tileCut(const vts::TileId &tileId, const vts::Mesh &mesh
 
 void cutToTiles(tools::TmpTileset &ts, const vef::Archive &archive
                 , const math::Extents2 &worldExtents
-                , const boost::optional<geo::SrsDefinition> &dstSrs
+                , const std::optional<geo::SrsDefinition> &dstSrs
                 , int maxLod, double clipMargin
                 , int lodDepth)
 {
-    Cutter(ts, archive, worldExtents
-           , math::extent(worldExtents, 2), dstSrs
-           , maxLod, clipMargin, lodDepth)();
+    TileCutterConfig config;
+    config.worldExtents = worldExtents;
+    config.dstSrs = dstSrs;
+    config.maxLod = maxLod;
+    config.clipMargin = clipMargin;
+    config.lodDepth = lodDepth;
+
+    Cutter(ts, archive, config)();
 }
 
 void cutToTiles(tools::TmpTileset &ts, const vef::Archive &archive
                 , const math::Extents3 &worldExtents
-                , const boost::optional<geo::SrsDefinition> &dstSrs
+                , const std::optional<geo::SrsDefinition> &dstSrs
                 , int maxLod, double clipMargin
                 , int lodDepth)
 {
-    Cutter(ts, archive, math::extents2(worldExtents)
-           , math::extent(worldExtents, 2), dstSrs
-           , maxLod, clipMargin, lodDepth)();
+    TileCutterConfig config;
+    config.worldExtents = worldExtents;
+    config.dstSrs = dstSrs;
+    config.maxLod = maxLod;
+    config.clipMargin = clipMargin;
+    config.lodDepth = lodDepth;
+
+    Cutter(ts, archive, config)();
+}
+
+void cutToTiles(vtslibs::vts::tools::TmpTileset &ts
+                , const vef::Archive &archive
+                , const TileCutterConfig &config)
+{
+    Cutter(ts, archive, config)();
 }
 
 } // namespace vef

--- a/vef/tilecutter.cpp
+++ b/vef/tilecutter.cpp
@@ -72,6 +72,9 @@ WindowRecord::list windowRecordList(const vef::Archive &archive
     for (const auto &lw : archive.manifest().windows) {
         const auto trafo(vef::windowMatrix(archive.manifest(), lw));
         auto lod(config.maxLod);
+        const auto topLod(config.tileExtents
+                          ? config.tileExtents->lod
+                          : 0);
 
         std::size_t bLod(0);
         std::size_t eLod(lw.lods.size());
@@ -89,7 +92,10 @@ WindowRecord::list windowRecordList(const vef::Archive &archive
 
         std::size_t i(0);
         for (const auto &w : lw.lods) {
-            // TODO: apply tileExtents lod here as well
+            if (lod < topLod) {
+                // tile extents limit
+                break;
+            }
             if ((i >= bLod) && (i < eLod)) {
                 list.emplace_back(w, lod, trafo);
             }

--- a/vef/tilecutter.hpp
+++ b/vef/tilecutter.hpp
@@ -96,7 +96,8 @@ struct TileCutterConfig {
      */
     std::optional<geo::SrsDefinition> dstSrs;
 
-    /** Maximum lod to process from inpout
+    /** Archive's original data LOD i mapped to privided `maxLod` which defines
+     *  finest tiles.
      */
     int maxLod = 0;
 

--- a/vef/tilecutter.hpp
+++ b/vef/tilecutter.hpp
@@ -32,6 +32,9 @@
  *  VEF.
  */
 
+#include <optional>
+#include <variant>
+
 #include "vts-libs/tools-support/tmptileset.hpp"
 
 #include "reader.hpp"
@@ -56,7 +59,7 @@ namespace vef {
 void cutToTiles(vtslibs::vts::tools::TmpTileset &ts
                 , const vef::Archive &archive
                 , const math::Extents2 &worldExtents
-                , const boost::optional<geo::SrsDefinition> &dstSrs
+                , const std::optional<geo::SrsDefinition> &dstSrs
                 , int maxLod, double clipMargin = 1.0 / 128.
                 , int lodDepth = 0);
 
@@ -78,9 +81,45 @@ void cutToTiles(vtslibs::vts::tools::TmpTileset &ts
 void cutToTiles(vtslibs::vts::tools::TmpTileset &ts
                 , const vef::Archive &archive
                 , const math::Extents3 &worldExtents
-                , const boost::optional<geo::SrsDefinition> &dstSrs
+                , const std::optional<geo::SrsDefinition> &dstSrs
                 , int maxLod, double clipMargin = 1.0 / 128.
                 , int lodDepth = 0);
+
+using WorldExtents = std::variant<math::Extents2, math::Extents3>;
+
+struct TileCutterConfig {
+    /** Extents2 (for quadro division) or Extents3 (for octo division)
+     */
+    WorldExtents worldExtents;
+
+    /** Destination SRS, if different than input srs.
+     */
+    std::optional<geo::SrsDefinition> dstSrs;
+
+    /** Maximum lod to process from inpout
+     */
+    int maxLod = 0;
+
+    /** Clipping margin:
+     * >=0: margin = tileSize * clipMargin  # fraction of tile size
+     *  <0: margin = -clipMargin            # absolute dimension
+     */
+    double clipMargin = 1.0 / 128.;
+
+    /** =0: nothing happens
+     *  >0: only bottom lodDepth lods are processed from the input
+     *  <0: only top -lodDepth lods are processed from the input
+     */
+    int lodDepth = 0;
+
+    /** Limit output to given tile subtree if set.
+     */
+    std::optional<vtslibs::vts::LodTileRange> tileExtents;
+};
+
+void cutToTiles(vtslibs::vts::tools::TmpTileset &ts
+                , const vef::Archive &archive
+                , const TileCutterConfig &config);
 
 } // namespace vef
 

--- a/vef/tiling-po.cpp
+++ b/vef/tiling-po.cpp
@@ -77,7 +77,7 @@ void worldConfiguration(po::options_description &od)
         ;
 }
 
-void configureWorld(boost::optional<vef::World> &world
+void configureWorld(std::optional<vef::World> &world
                     , const po::variables_map &vars)
 {
     bool w(vars.count("world"));

--- a/vef/tiling-po.hpp
+++ b/vef/tiling-po.hpp
@@ -36,7 +36,7 @@ namespace vef {
 
 void worldConfiguration(boost::program_options::options_description &od);
 
-void configureWorld(boost::optional<vef::World> &world
+void configureWorld(std::optional<vef::World> &world
                     , const boost::program_options::variables_map &vars);
 
 } // namespace vef

--- a/vef/tiling.cpp
+++ b/vef/tiling.cpp
@@ -309,8 +309,8 @@ struct MeshParams {
 };
 
 inline double pixelArea(const MeshArea &area
-                        , const boost::optional<double> &resolution
-                        = boost::none)
+                        , const std::optional<double> &resolution
+                        = std::nullopt)
 {
     // override
     if (resolution) { return math::sqr(resolution.value()); }
@@ -329,7 +329,7 @@ inline bool compatible(const geo::SrsDefinition &srs)
 
 MeshParams
 analyzeMesh(const Archive &archive
-            , const boost::optional<double> &resolution = boost::none)
+            , const std::optional<double> &resolution = std::nullopt)
 {
     const auto &srs(archive.manifest().srs.value());
 
@@ -363,7 +363,7 @@ analyzeMesh(const Archive &archive
 
 MeshParams
 analyzeMesh(const Archives &archives
-            , const boost::optional<double> &resolution = boost::none)
+            , const std::optional<double> &resolution = std::nullopt)
 {
     if (archives.size() == 1) {
         // single archive
@@ -412,7 +412,7 @@ analyzeMesh(const Archives &archives
 MeshParams
 analyzeMesh(const Archives &archives
             , const geo::SrsDefinition &srs
-            , const boost::optional<double> &resolution = boost::none)
+            , const std::optional<double> &resolution = std::nullopt)
 {
     // work in given SRS
     MeshInfo mi;
@@ -448,8 +448,8 @@ math::Extents3 makeExtents(const math::Point3 &center
 Tiling::Tiling(const Archives &archives
                , const math::Size2 &optimalTextureSize
                , bool for3dCutting
-               , const boost::optional<double> &resolution
-               , const boost::optional<World> &world
+               , const std::optional<double> &resolution
+               , const std::optional<World> &world
                , std::size_t extraLods)
     : maxLod()
 {

--- a/vef/tiling.hpp
+++ b/vef/tiling.hpp
@@ -31,7 +31,7 @@
  *  kind of tiling hierarchy. It makes sense to put tiling support along VEF.
  */
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "reader.hpp"
 
@@ -71,22 +71,22 @@ struct Tiling {
     Tiling(const Archive &archive
            , const math::Size2 &optimalTextureSize
            , bool for3dCutting = false
-           , const boost::optional<double> &resolution = boost::none
-           , const boost::optional<World> &world = boost::none
+           , const std::optional<double> &resolution = std::nullopt
+           , const std::optional<World> &world = std::nullopt
            , std::size_t extraLods = 0);
 
     Tiling(const Archive::list &archives
            , const math::Size2 &optimalTextureSize
            , bool for3dCutting = false
-           , const boost::optional<double> &resolution = boost::none
-           , const boost::optional<World> &world = boost::none
+           , const std::optional<double> &resolution = std::nullopt
+           , const std::optional<World> &world = std::nullopt
            , std::size_t extraLods = 0);
 
     Tiling(const Archives &archives
            , const math::Size2 &optimalTextureSize
            , bool for3dCutting = false
-           , const boost::optional<double> &resolution = boost::none
-           , const boost::optional<World> &world = boost::none
+           , const std::optional<double> &resolution = std::nullopt
+           , const std::optional<World> &world = std::nullopt
            , std::size_t extraLods = 0);
 
     Tiling(std::ostream &os);
@@ -99,8 +99,8 @@ struct Tiling {
 inline Tiling::Tiling(const Archive &archive
                       , const math::Size2 &optimalTextureSize
                       , bool for3dCutting
-                      , const boost::optional<double> &resolution
-                      , const boost::optional<World> &world
+                      , const std::optional<double> &resolution
+                      , const std::optional<World> &world
                       , std::size_t extraLods)
     : Tiling(Archives({std::cref(archive)})
              , optimalTextureSize, for3dCutting, resolution, world
@@ -110,8 +110,8 @@ inline Tiling::Tiling(const Archive &archive
 inline Tiling::Tiling(const Archive::list &archives
                       , const math::Size2 &optimalTextureSize
                       , bool for3dCutting
-                      , const boost::optional<double> &resolution
-                      , const boost::optional<World> &world
+                      , const std::optional<double> &resolution
+                      , const std::optional<World> &world
                       , std::size_t extraLods)
     : Tiling(Archives(archives.begin(), archives.end())
              , optimalTextureSize, for3dCutting, resolution, world


### PR DESCRIPTION
Reworked tile-cutting interface to get all parameters in `TileCutterConfig`. Added optional `TileCutterConfig::tileExtents` that limits tile subtree that is emitted to output.

NB: affected interfaces switched from boost::optional to std::optional
NB: v1.11